### PR TITLE
escape % for latex in to_kable

### DIFF
--- a/R/to_kable.R
+++ b/R/to_kable.R
@@ -214,7 +214,8 @@ to_kable <- function(
 
     # remove group/variable columns
     # rename remaining columns for printing
-    k1 %<>%
+    k1 %<>% # boyiguo1 added gsub
+      mutate(labels = gsub("%", "\\\\%", labels)) %>%
       select(
         ` ` = labels,
         everything(),


### PR DESCRIPTION
I added one line in the _to_kable_ where gsub all the % in _label_ with "////%" to escape properly.

Won’t interfere with other pull request