### PR TITLE
Fix build meta

### DIFF
--- a/R/build_meta.R
+++ b/R/build_meta.R
@@ -61,7 +61,8 @@ build_meta <- function(
 
   mta_data <- tibble::tibble(
     variable = names(data),
-    type     = map_chr(data, class),
+    # type     = map_chr(data, class),
+    type     = map_chr(variable, ~get_class(data, .x)),
     n_unique = map_int(data, ~length(unique(na.omit(.x)))),
     label    = map_chr(variable, ~get_label(data, .x)),
     unit     = map_chr(variable, ~get_units(data, .x)),

--- a/R/get_funs.R
+++ b/R/get_funs.R
@@ -60,3 +60,27 @@ get_groups <- function(data, col){
   attr(data[[col]],'group') %||% "None"
 
 }
+
+# If this column belongs to multiple classes, return the primitive class type.
+# Otherwise, return NA_character_ and report warning
+# @param data a dataframe.
+# @param col a column name in `data`
+
+get_class <- function(data, col){
+
+  class_vec <- class(data[[col]])
+  # class_vec <- class(col)
+  #
+  ret <- intersect(class_vec,  c('factor', 'numeric', 'integer'))
+
+  if(length(ret) == 1) return(ret)
+  else if(length(ret) == 0) stop(glue("Variable {col} doesn't contains any of the 'factor', 'numeric', 'integer' classes"))
+  else if(length(ret) >1) stop(glue("Variable {col} contains more than one of the 'factor', 'numeric', 'integer' classes"))
+  # I don't know why, but this doesn't work. Probably because of the ret
+  # case_when(
+  #   length(ret) == 1 ~ ret,
+  #   length(ret) == 0 ~ stop(glue("Variable {col} doesn't contains any of the 'factor', 'numeric', 'integer' classes")),
+  #   length(ret) >1  ~ stop(glue("Variable {col} contains more than one of the 'factor', 'numeric', 'integer' classes"))
+  #           )
+
+}

--- a/tests/testthat/test-build_meta.R
+++ b/tests/testthat/test-build_meta.R
@@ -1,0 +1,25 @@
+df <- data.frame(
+  A = c(1,2,3),
+  B = factor(c("One", "", "Three"), levels = c("One", "", "Three")),
+  C = factor(c("One", "Two", " "), levels = c("One", "Two", " "))
+)
+
+class(df$C) <- "TestClass"
+
+test_that("build_meta throws an error for a class that is other than 'factor', 'integer', 'numeric'", {
+  expect_error(tbl_one <- tibble_one(
+    data = df,
+    formula = ~ .,
+    include_pval = TRUE
+  ))
+})
+
+class(df$C) <- c("factor", "integer")
+
+test_that("build_meta throws an error for a class that contains more than one of  'factor', 'integer', 'numeric'", {
+  expect_error(tbl_one <- tibble_one(
+    data = df,
+    formula = ~ .,
+    include_pval = TRUE
+  ))
+})

--- a/tests/testthat/test-tibble_one.R
+++ b/tests/testthat/test-tibble_one.R
@@ -194,7 +194,8 @@ test_that("incorrect types are handled correctly", {
       formula = ~ a+b,
       specs_table_vals = 'median'
     ),
-    regexp = 'tibble_one is compatible with'
+    #regexp = 'tibble_one is compatible with'
+    regexp = "Variable a doesn't contains any of"
   )
 
   df <- data.frame(a = 1:n, b = NA_real_)


### PR DESCRIPTION
* Added a new function to return single class that is in 'factor', 'numeric', 'integer', or sending error message accordingly

* Added a naive test case for it

* had to modified tibbleOne error message, as this examining class in build_meta happens before check_meta or similar check up for class